### PR TITLE
Addendum: `isapprox`

### DIFF
--- a/src/TaylorSeries.jl
+++ b/src/TaylorSeries.jl
@@ -36,7 +36,8 @@ import Base: zero, one, zeros, ones, isinf, isnan,
     sqrt, exp, log, sin, cos, tan,
     asin, acos, atan, sinh, cosh, tanh,
     A_mul_B!, power_by_squaring,
-    getindex, setindex!, endof, norm
+    getindex, setindex!, endof, norm,
+    rtoldefault, isfinite, isapprox
 
 export Taylor1, TaylorN, HomogeneousPolynomial, AbstractSeries
 

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -13,8 +13,7 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
         @eval ($f)(a::$T) = $T(($f).(a.coeffs), a.order)
     end
 
-    @eval real{T<:NumberNotSeries}(x::Type{$T{T}}) = typeof(real(zero(x)))
-    @eval real{T<:AbstractSeries}(x::Type{$T{T}}) = real(T)
+    @eval real{T<:Number}(x::Type{$T{T}}) = typeof(real(zero(x)))
 
     @eval ctranspose(a::$T) = conj.(a)
 

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -139,9 +139,21 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
 end
 
 # isfinite
+"""
+    isfinite(x::AbstractSeries) -> Bool
+
+Test whether the coefficients of the polynomial `x` are finite.
+"""
 isfinite(x::AbstractSeries) = !isnan(x) && !isinf(x)
 
 # isapprox; modified from Julia's Base.isapprox
+"""
+    isapprox(x::AbstractSeries, y::AbstractSeries; [rtol::Real=sqrt(eps), atol::Real=0, nans::Bool=false])
+
+Inexact equality comparison between polynomials: returns `true` if 
+`norm(x-y,1) <= atol + rtol*max(norm(x,1), norm(y,1))`, where `x` and `y` are 
+polynomials. For more details, see [`Base.isapprox`](@ref).
+"""
 function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rtoldefault(x,y), atol::Real=0, nans::Bool=false)
     x == y || (isfinite(x) && isfinite(y) && norm(x-y,1) <= atol + rtol*max(norm(x,1), norm(y,1))) || (nans && isnan(x) && isnan(y))
 end

--- a/src/other_functions.jl
+++ b/src/other_functions.jl
@@ -140,7 +140,7 @@ for T in (:Taylor1, :HomogeneousPolynomial, :TaylorN)
 end
 
 # isfinite
-isfinite(x::AbstractSeries) = !isinf(x)
+isfinite(x::AbstractSeries) = !isnan(x) && !isinf(x)
 
 # isapprox; modified from Julia's Base.isapprox
 function isapprox{T<:AbstractSeries,S<:AbstractSeries}(x::T, y::S; rtol::Real=rtoldefault(x,y), atol::Real=0, nans::Bool=false)

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -351,7 +351,7 @@ using Base.Test
     b[3][3] = NaN
     @test !isfinite(b)
     b[3][3] = a[3][3]+eps()
-    @test a[3] ≈ b[3]
+    @test isapprox(a[3], b[3], rtol=eps())
     @test a ≈ b
     b[2][2] = a[2][2]+sqrt(eps())
     @test a[2] ≈ b[2]

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -335,6 +335,26 @@ using Base.Test
     @test norm(a,Inf) == 8.
     @test norm((3.+4im)*x) == abs(3.+4im)
 
+    @test TaylorSeries.rtoldefault(TaylorN{Int64}) == 0
+    @test TaylorSeries.rtoldefault(TaylorN{Float64}) == sqrt(eps(Float64))
+    @test TaylorSeries.rtoldefault(TaylorN{BigFloat}) == sqrt(eps(BigFloat))
+    @test TaylorSeries.real(TaylorN{Float64}) == TaylorN{Float64}
+    @test TaylorSeries.real(TaylorN{Complex{Float64}}) == TaylorN{Float64}
+    @test isfinite(a)
+    @test a[1] ≈ a[1]
+    @test a[2] ≈ a[2]
+    @test a[3] ≈ a[3]
+    @test a ≈ a
+    b = deepcopy(a)
+    b[3][3] = Inf
+    @show b
+    @test !isfinite(b)
+    b[3][3] = a[3][3]+eps()
+    @test a[3] ≈ b[3]
+    @test a ≈ b
+    b[2][2] = a[2][2]+sqrt(eps())
+    @test a[2] ≈ b[2]
+    @test a ≈ b
 
     @test string(-xH) == " - 1 x₁"
     @test string(xT^2) == " 1 x₁² + 𝒪(‖x‖¹⁸)"

--- a/test/manyvariables.jl
+++ b/test/manyvariables.jl
@@ -347,7 +347,8 @@ using Base.Test
     @test a ≈ a
     b = deepcopy(a)
     b[3][3] = Inf
-    @show b
+    @test !isfinite(b)
+    b[3][3] = NaN
     @test !isfinite(b)
     b[3][3] = a[3][3]+eps()
     @test a[3] ≈ b[3]

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -169,12 +169,14 @@ using Base.Test
     @test isapprox(P, Q, rtol=1.0)
     Q[2][2] = P[2][2]+10sqrt(eps())
     @test !isapprox(P, Q, atol=sqrt(eps()), rtol=0)
+    @test P ≉ Q^2
     Q[2][2] = P[2][2]+eps()/2
     @test isapprox(Q, Q, atol=eps(), rtol=0)
     @test isapprox(Q, P, atol=eps(), rtol=0)
     Q[2][1] = P[2][1]-10eps()
     @test !isapprox(Q, P, atol=eps(), rtol=0)
-
+    @test P ≉ Q^2
+    
     X, Y = set_variables(BigFloat, "x y", numvars=2, order=6)
     p1N = Taylor1([X^2,X*Y,Y+X,Y^2])
     q1N = Taylor1([X^2,(1.0+sqrt(eps(BigFloat)))*X*Y,Y+X,Y^2])

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -139,4 +139,44 @@ using Base.Test
     @test norm(X) > 0
     @test norm(X+Y) == sqrt(2)
     @test norm(-10X+4Y,Inf) == 10.
+
+    @test TaylorSeries.rtoldefault(TaylorN{Taylor1{Int64}}) == 0
+    @test TaylorSeries.rtoldefault(Taylor1{TaylorN{Int64}}) == 0
+    for T in (Float64, BigFloat)
+        @test TaylorSeries.rtoldefault(TaylorN{Taylor1{T}}) == sqrt(eps(T))
+        @test TaylorSeries.rtoldefault(Taylor1{TaylorN{T}}) == sqrt(eps(T))
+        @test TaylorSeries.real(TaylorN{Taylor1{T}}) == TaylorN{Taylor1{T}}
+        @test TaylorSeries.real(Taylor1{TaylorN{T}}) == Taylor1{TaylorN{T}}
+        @test TaylorSeries.real(TaylorN{Taylor1{Complex{T}}}) == TaylorN{Taylor1{T}}
+        @test TaylorSeries.real(Taylor1{TaylorN{Complex{T}}}) == Taylor1{TaylorN{T}}
+    end
+
+    rndT1(ord1) = Taylor1(-1+2rand(ord1+1)) # generates a random Taylor1 with order `ord`
+    nmonod(s, d) = binomial(d+s-1, d) #number of monomials in s variables with exact degree d
+    #rndHP generates a random `ordHP`-th order homog. pol. of Taylor1s, each with order `ord1`
+    rndHP(ordHP, ord1) = HomogeneousPolynomial( [rndT1(ord1) for i in 1:nmonod(get_numvars(), ordHP)] )
+    #rndTN generates a random `ordHP`-th order TaylorN of of Taylor1s, each with order `ord1`
+    rndTN(ordN, ord1) = TaylorN([rndHP(i, ord1) for i in 0:ordN])
+
+    P = rndTN(get_order(), 3)
+    @test P ≈ P
+    Q = deepcopy(P)
+    Q[2][2] = Taylor1([NaN, Inf])
+    @test isnan(Q)
+    @test isinf(Q)
+    @test !isfinite(Q)
+    Q[2][2] = P[2][2]+sqrt(eps())/2
+    @test isapprox(P, Q, rtol=1.0)
+    Q[2][2] = P[2][2]+10sqrt(eps())
+    @test !isapprox(P, Q, atol=sqrt(eps()), rtol=0)
+    Q[2][2] = P[2][2]+eps()/2
+    @test isapprox(Q, Q, atol=eps(), rtol=0)
+    @test isapprox(Q, P, atol=eps(), rtol=0)
+    Q[2][1] = P[2][1]-10eps()
+    @test !isapprox(Q, P, atol=eps(), rtol=0)
+
+    p1N = Taylor1([X^2,X*Y,Y+X,Y^2])
+    q1N = Taylor1([X^2,(1.0+sqrt(eps()))*X*Y,Y+X,Y^2])
+    @test p1N ≈ p1N
+    @test p1N ≈ q1N
 end

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -175,6 +175,7 @@ using Base.Test
     Q[2][1] = P[2][1]-10eps()
     @test !isapprox(Q, P, atol=eps(), rtol=0)
 
+    X, Y = set_variables("x y", numvars=2, order=6)
     p1N = Taylor1([X^2,X*Y,Y+X,Y^2])
     q1N = Taylor1([X^2,(1.0+sqrt(eps()))*X*Y,Y+X,Y^2])
     @test p1N ≈ p1N

--- a/test/mixtures.jl
+++ b/test/mixtures.jl
@@ -175,9 +175,9 @@ using Base.Test
     Q[2][1] = P[2][1]-10eps()
     @test !isapprox(Q, P, atol=eps(), rtol=0)
 
-    X, Y = set_variables("x y", numvars=2, order=6)
+    X, Y = set_variables(BigFloat, "x y", numvars=2, order=6)
     p1N = Taylor1([X^2,X*Y,Y+X,Y^2])
-    q1N = Taylor1([X^2,(1.0+sqrt(eps()))*X*Y,Y+X,Y^2])
+    q1N = Taylor1([X^2,(1.0+sqrt(eps(BigFloat)))*X*Y,Y+X,Y^2])
     @test p1N ≈ p1N
     @test p1N ≈ q1N
 end

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -274,6 +274,34 @@ using Base.Test
     @test norm(Taylor1(a,15),3) == sum((a.^3))^(1/3)
     @test norm(t_a,Inf) == 12
     @test norm(t_C) == abs(3.+4im)
+
+    @test TaylorSeries.rtoldefault(Taylor1{Int64}) == 0
+    @test TaylorSeries.rtoldefault(Taylor1{Float64}) == sqrt(eps(Float64))
+    @test TaylorSeries.rtoldefault(Taylor1{BigFloat}) == sqrt(eps(BigFloat))
+    @test TaylorSeries.real(Taylor1{Float64}) == Taylor1{Float64}
+    @test TaylorSeries.real(Taylor1{Complex{Float64}}) == Taylor1{Float64}
+    @test isfinite(t_C)
+    @test isfinite(t_a)
+    s = Taylor1([Inf, Inf, 0])
+    @test !isfinite(s)
+    b = convert(Vector{Float64}, a)
+    b[3] += eps(10.0)
+    b[5] -= eps(10.0)
+    t_b = Taylor1(b,15)
+    t_C2 = Taylor1(3.+4im+eps(100.0),5)
+    t_C3 = Taylor1(3.+4im+eps(100.0)*im,5)
+    @test isapprox(t_C, t_C)
+    @test t_a ≈ t_a
+    @test t_a ≈ t_b
+    @test t_C ≈ t_C2
+    @test t_C ≈ t_C3
+    @test t_C3 ≈ t_C2
+    t = Taylor1(25)
+    p = sin(t)
+    q = sin(t+eps())
+    @test t ≈ t
+    @test t ≈ t+sqrt(eps())
+    @test isapprox(p, q, atol=eps())
 end
 
 @testset "Matrix multiplication for Taylor1" begin

--- a/test/onevariable.jl
+++ b/test/onevariable.jl
@@ -282,8 +282,8 @@ using Base.Test
     @test TaylorSeries.real(Taylor1{Complex{Float64}}) == Taylor1{Float64}
     @test isfinite(t_C)
     @test isfinite(t_a)
-    s = Taylor1([Inf, Inf, 0])
-    @test !isfinite(s)
+    @test !isfinite( Taylor1([0, Inf]) )
+    @test !isfinite( Taylor1([NaN, 0]) )
     b = convert(Vector{Float64}, a)
     b[3] += eps(10.0)
     b[5] -= eps(10.0)


### PR DESCRIPTION
Hi, @blas-ko! This PR elaborates on JuliaDiff/TaylorSeries.jl#128, adding `isapprox` and auxiliary methods (`rtoldefault`, `isfinite`, `real`), as well as corresponding tests... Hope this is useful, and if there's any other way I might help, please let me know!